### PR TITLE
Add cpptango and tango-idl conda packages - First GitHub workflow

### DIFF
--- a/.github/workflows/build_conda_pkg_workflow.yaml
+++ b/.github/workflows/build_conda_pkg_workflow.yaml
@@ -1,0 +1,51 @@
+name: Build conda packages
+# This workflow is triggered on pushes to the repository.
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build tango-idl and cpptango conda packages
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      # This step check out a copy of your repository
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      # Display OS release
+      - name: Display os-release
+        run: cat /etc/os-release
+      # Setup miniconda
+      - name: Setup miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          activate-environment: conda_pkg_build_env
+      - name: install conda-build
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda install conda-build
+          conda config --add channels conda-forge
+      - name: install conda-verify
+        run: conda install conda-verify
+      - name: Build tango-idl Conda package
+        shell: bash -l {0}
+        run: |
+          conda build $GITHUB_WORKSPACE/conda-recipes/tango-idl --output-folder=$GITHUB_WORKSPACE/dist-idl
+      - name: Build cpptango Conda package
+        shell: bash -l {0}
+        run: |
+          conda build $GITHUB_WORKSPACE/conda-recipes/cpptango --output-folder=$GITHUB_WORKSPACE/dist-cpptango
+      - name: Prepare artifacts
+        shell: bash -l {0}
+        run: |
+          mkdir $GITHUB_WORKSPACE/artifacts
+          cp $GITHUB_WORKSPACE/dist-idl/linux-64/tango-idl*.bz2 $GITHUB_WORKSPACE/artifacts/
+          cp $GITHUB_WORKSPACE/dist-cpptango/linux-64/cpptango*.bz2 $GITHUB_WORKSPACE/artifacts/
+          ls -l $GITHUB_WORKSPACE/artifacts
+      - name: Upload Conda Packages as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: tango-idl-and-cpptango-conda-packages
+          path: artifacts

--- a/.github/workflows/build_conda_pkg_workflow.yaml
+++ b/.github/workflows/build_conda_pkg_workflow.yaml
@@ -32,11 +32,11 @@ jobs:
       - name: Build tango-idl Conda package
         shell: bash -l {0}
         run: |
-          conda build $GITHUB_WORKSPACE/conda-recipes/tango-idl --output-folder=$GITHUB_WORKSPACE/dist-idl
+          conda build $GITHUB_WORKSPACE/tango-idl --output-folder=$GITHUB_WORKSPACE/dist-idl
       - name: Build cpptango Conda package
         shell: bash -l {0}
         run: |
-          conda build $GITHUB_WORKSPACE/conda-recipes/cpptango --output-folder=$GITHUB_WORKSPACE/dist-cpptango
+          conda build $GITHUB_WORKSPACE/cpptango --output-folder=$GITHUB_WORKSPACE/dist-cpptango
       - name: Prepare artifacts
         shell: bash -l {0}
         run: |

--- a/cpptango/build.sh
+++ b/cpptango/build.sh
@@ -1,0 +1,12 @@
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_VERBOSE_MAKEFILE=true \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DOMNI_BASE=$PREFIX \
+      -DZMQ_BASE=$PREFIX \
+      -DIDL_BASE=$PREFIX \
+      -DBUILD_TESTING=OFF \
+      ..
+
+make -j `nproc` install

--- a/cpptango/meta.yaml
+++ b/cpptango/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "9.3.4-rc2" %}
+
+package:
+  name: cpptango
+  version: "9.3.4rc2"
+
+source:
+  git_url: https://github.com/tango-controls/cppTango.git
+  git_rev: {{ version }}
+
+requirements:
+  build:
+    - libtool
+    - {{ compiler('cxx') }}
+    - cmake
+  host:
+    - omniorb
+    - zeromq
+    - cppzmq
+    - tango-idl
+  run:
+    - {{ pin_compatible('omniorb') }}
+    - {{ pin_compatible('zeromq') }}
+
+about:
+  home: https://www.tango-controls.org
+  license: LGPL-3.0
+  license_file: LICENSE
+  summary: 'Tango-Controls C++ library'
+  description: |
+   This is the Tango-Controls C++ library (a.k.a. cppTango). 
+   Tango-Controls is a software toolkit for building control systems.
+  dev_url: https://github.com/tango-controls/cppTango
+  doc_url: https://tango-controls.github.io/cppTango-docs
+  doc_source_url: https://github.com/tango-controls/cppTango-docs

--- a/tango-idl/build.sh
+++ b/tango-idl/build.sh
@@ -1,0 +1,5 @@
+mkdir build-cmake
+cd build-cmake
+
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..
+make install

--- a/tango-idl/meta.yaml
+++ b/tango-idl/meta.yaml
@@ -1,0 +1,18 @@
+{% set version = "5.0.1" %}
+
+package:
+  name: tango-idl
+  version: "{{ version }}"
+
+source:
+  git_rev: {{ version }}
+  git_url: https://github.com/tango-controls/tango-idl.git
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+
+about:
+  home: http://www.tango-controls.org
+  license: LGPL3
+#  license_file: COPYING
+  summary: A software toolkit for building control systems


### PR DESCRIPTION
First attempt to build tango-idl and cpptango specific conda packages from their respective git repositories.

This version is currently getting the dependencies from conda-forge instead of tango-controls conda channel (because there is a new dependency to cppzmq which is not yet in tango-controls channel).

A first version of github workflow had been added to automatically build tango-idl and cpptango conda packages with Github workflow. The packages are available as an artifact if the build succeeded.

This can be improved in the future to have 1 artifact per package.