### PR TITLE
Add tango-test conda recipe for TangoTest DS Fix #2

### DIFF
--- a/.github/workflows/build_conda_pkg_workflow.yaml
+++ b/.github/workflows/build_conda_pkg_workflow.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build tango-idl and cpptango conda packages
+    name: Build tango-idl, cpptango and tango-test conda packages
     # This job runs on Linux
     runs-on: ubuntu-latest
 
@@ -21,37 +21,37 @@ jobs:
         with:
           auto-update-conda: true
           activate-environment: conda_pkg_build_env
-      - name: install conda-build
+      - name: install conda-build and conda-verify
         shell: bash -l {0}
         run: |
           conda info
           conda install conda-build
+          conda install conda-verify
           conda config --add channels conda-forge
-      - name: install conda-verify
-        run: conda install conda-verify
       - name: Build tango-idl Conda package
         shell: bash -l {0}
         run: |
-          conda build $GITHUB_WORKSPACE/tango-idl --output-folder=$GITHUB_WORKSPACE/dist-idl
-      - name: Build cpptango Conda package
-        shell: bash -l {0}
-        run: |
-          conda build $GITHUB_WORKSPACE/cpptango --output-folder=$GITHUB_WORKSPACE/dist-cpptango
-      - name: Prepare artifacts
-        shell: bash -l {0}
-        run: |
-          mkdir $GITHUB_WORKSPACE/artifacts
-          cp $GITHUB_WORKSPACE/dist-idl/linux-64/tango-idl*.bz2 $GITHUB_WORKSPACE/artifacts/
-          cp $GITHUB_WORKSPACE/dist-cpptango/linux-64/cpptango*.bz2 $GITHUB_WORKSPACE/artifacts/
-          ls -l $GITHUB_WORKSPACE/artifacts
+          conda build $GITHUB_WORKSPACE/tango-idl --output-folder=$GITHUB_WORKSPACE/dist
       - name: Upload tango-idl Conda Package as artifact
         uses: actions/upload-artifact@v2
         with:
           name: tango-idl-linux-64-conda-package
-          path: artifacts/tango-idl*.bz2
+          path: dist/linux-64/tango-idl*.bz2
+      - name: Build cpptango Conda package
+        shell: bash -l {0}
+        run: |
+          conda build $GITHUB_WORKSPACE/cpptango --output-folder=$GITHUB_WORKSPACE/dist
       - name: Upload cpptango Conda Package as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: cpptango-idl-linux-64-conda-package
-          path: artifacts/cpptango*.bz2
-
+          name: cpptango-linux-64-conda-package
+          path: dist/linux-64/cpptango*.bz2
+      - name: Build tango-test Conda package
+        shell: bash -l {0}
+        run: |
+          conda build $GITHUB_WORKSPACE/tango-test --output-folder=$GITHUB_WORKSPACE/dist
+      - name: Upload tango-test Conda Package as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: tango-test-linux-64-conda-package
+          path: dist/linux-64/tango-test*.bz2

--- a/tango-test/build.sh
+++ b/tango-test/build.sh
@@ -1,0 +1,9 @@
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_VERBOSE_MAKEFILE=true \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      ..
+
+export MAKEFLAGS="-j `nproc`"
+cmake --build . --target install

--- a/tango-test/meta.yaml
+++ b/tango-test/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "3.0" %}
+
+package:
+  name: tango-test
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/tango-controls/TangoTest.git
+  git_rev: {{ version }}
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - libtool
+    - {{ compiler('cxx') }}
+    - cmake
+  host:
+    - cppzmq
+    - cpptango
+  run:
+    - {{ pin_compatible('omniorb') }}
+    - {{ pin_compatible('cpptango') }}
+
+about:
+  home: https://www.tango-controls.org
+  license: GPL-3.0
+  #license_file: LICENSE
+  summary: 'TangoTest device server'
+  description: |
+   This is the Tango-Controls TangoTest device server.
+   A famous TANGO device server developed for testing. 
+   Tango-Controls is a software toolkit for building control systems.
+  dev_url: https://github.com/tango-controls/TangoTest
+  doc_url: https://tango-controls.readthedocs.io/en/latest/tutorials-and-howtos/how-tos/how-to-try-tango.html#play-with-tango-controls
+  doc_source_url: https://github.com/tango-controls/TangoTest/tree/master/doc_html


### PR DESCRIPTION
- Update build_conda_pkg Github workflow for tango-test.
- Build as well a Conda package for TangoTest Device Server.
- Fix name of the cpptango conda package github action artifact.
- Upload artifacts immediately after building each package.
- Install conda-verify in the same step as conda-build.
- Use same output folder for conda-build to avoid rebuilding several times the same package
and to solve the potential dependency issues.
- Change github workflow job description.