### PR TITLE
cpptango 9.3.4 rc6 conda recipe

### DIFF
--- a/cpptango/meta.yaml
+++ b/cpptango/meta.yaml
@@ -1,12 +1,17 @@
-{% set version = "9.3.4-rc5" %}
+{% set version = "9.3.4-rc6" %}
 
 package:
   name: cpptango
-  version: "9.3.4rc5"
+  version: "9.3.4rc6"
 
 source:
   git_url: https://github.com/tango-controls/cppTango.git
   git_rev: {{ version }}
+
+build:
+  number: 0
+  run_exports :
+    - {{ pin_subpackage('cpptango', min_pin='x.x', max_pin='x.x') }}
 
 requirements:
   build:
@@ -15,12 +20,11 @@ requirements:
     - cmake
   host:
     - omniorb
-    - zeromq
     - cppzmq
     - tango-idl
   run:
-    - {{ pin_compatible('omniorb') }}
-    - {{ pin_compatible('zeromq') }}
+    - {{ pin_compatible('omniorb', min_pin='x.x', max_pin='x.x') }}
+    - {{ pin_compatible('zeromq', min_pin='x.x', max_pin='x.x') }}
 
 about:
   home: https://www.tango-controls.org

--- a/tango-test/meta.yaml
+++ b/tango-test/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -20,8 +20,9 @@ requirements:
     - cppzmq
     - cpptango
   run:
-    - {{ pin_compatible('omniorb') }}
-    - {{ pin_compatible('cpptango') }}
+    - {{ pin_compatible ('cpptango', min_pin='x.x', max_pin='x.x') }}
+    - {{ pin_compatible ('omniorb', min_pin='x.x', max_pin='x.x') }}
+    - {{ pin_compatible ('zeromq', min_pin='x.x', max_pin='x.x') }}
 
 about:
   home: https://www.tango-controls.org


### PR DESCRIPTION
**cpptango**: 
- Added run_exports section to inform about the binary compatible cppTango versions.
- Removed zeromq host dependency which is already implied by cppzmq dependency and which would cause some conflicts in some situations.
- Loose pinning on omniorb and zeromq run dependencies.

**tango-test**:
- Loose pinning on cpptango, omniorb and zeromq run dependencies

