### PR TITLE
Update TangoTest conda recipe for TangoTest 3.1

### DIFF
--- a/tango-test/meta.yaml
+++ b/tango-test/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0" %}
+{% set version = "3.1" %}
 
 package:
   name: tango-test
@@ -9,7 +9,7 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
TangoTest 3.1: a potential crash in write_long_image has been fixed 
(https://github.com/tango-controls/TangoTest/issues/13, https://github.com/tango-controls/TangoTest/pull/14).
To be consistent, the same fix has been applied on write_xxx_spectrum and write_xxx_image methods.